### PR TITLE
WIP: Run tests inside Playgrounds

### DIFF
--- a/pg.sh
+++ b/pg.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Make some symlinks, so that we can use Quick in Xcode Playgrounds
+
+# From: http://stackoverflow.com/questions/3915040/bash-fish-command-to-print-absolute-path-to-a-file
+get_abs_filename() {
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+SDK_PATH="`xcrun --show-sdk-path`"
+FRAMEWORKS_PATH="$SDK_PATH/../../Library/Frameworks"
+AUX="$TMPDIR/com.apple.dt.Xcode.pg/auxiliarymodules"
+
+IFS=$'\n'
+for pg in `ls -d $AUX/*`
+do
+	for framework in `ls -d $(dirname $0)/vendor/Rome/*`
+	do
+		ln -sf `get_abs_filename $framework` $pg
+	done
+
+	ln -sf $FRAMEWORKS_PATH/XCTest.framework $pg
+done

--- a/vendor/Podfile
+++ b/vendor/Podfile
@@ -1,7 +1,7 @@
-platform :osx, '10.10'
+platform :osx, '10.9'
 use_frameworks!
 
 plugin 'cocoapods-rome'
 
-pod 'Quick', :head
-pod 'Nimble', :head
+pod 'Quick', :git => 'https://github.com/neonichu/Quick'
+pod 'Nimble', :git => 'https://github.com/neonichu/Nimble'


### PR DESCRIPTION
Currently works by linking them into the _auxiliarymodules_ directory. That allows importing them, unfortunately, there's a runtime error:

```
Playground execution failed: error: Couldn't lookup symbols:
  __TIFV6Nimble11Expectation12toEventuallyU__FGS0_Q__US_12BasicMatcher__FTQ_7timeoutSd12pollIntervalSd_T_A0_
  __TF6Nimble7containUSs12SequenceType_Ss9Equatable_USs13GeneratorType__FtGSaQ0___GVS_17NonNilMatcherFuncQ__
  _NMB_beTruthy
  _OBJC_CLASS_$_QuickSpec
  _qck_describe
  __TF6Nimble6expectU__FT4fileSS4lineSuFT_GSqQ___GVS_11ExpectationQ__
  __TF6Nimble8beTruthyFT_GVS_11MatcherFuncPSs11BooleanType__
  __TMPdV6Nimble11MatcherFunc
  __TIFV6Nimble11Expectation12toEventuallyU__FGS0_Q__US_12BasicMatcher__FTQ_7timeoutSd12pollIntervalSd_T_A1_
  __TFV6Nimble11Expectation2toU__fGS0_Q__US_18NonNilBasicMatcher__FQ_T_
  __TF5Quick2itFTSS5flagsGVSs10DictionarySSSb_4fileSS4lineSiFT_T__T_
  __TF6Nimble6expectU__FTKT_GSqQ__4fileSS4lineSu_GVS_11ExpectationQ__
  __TWPU__GV6Nimble17NonNilMatcherFuncQ__S_18NonNilBasicMatcherS_
  __TFV6Nimble11Expectation12toEventuallyU__fGS0_Q__US_12BasicMatcher__FTQ_7timeoutSd12pollIntervalSd_T_
  __TMPdV6Nimble17NonNilMatcherFunc
  __TWPU__GV6Nimble11MatcherFuncQ__S_12BasicMatcherS_
  _qck_context
  _OBJC_METACLASS_$_QuickSpec
  __TIF5Quick2itFTSS5flagsGVSs10DictionarySSSb_4fileSS4lineSiFT_T__T_A0_
  _NMB_contain
```

 ¯\_(ツ)_/¯ 
